### PR TITLE
fix: return nil when failed to get initial state

### DIFF
--- a/durablestore/dynamodb/durable_store.go
+++ b/durablestore/dynamodb/durable_store.go
@@ -60,9 +60,13 @@ func (s DynamoDurableStore) WriteState(ctx context.Context, state *egopb.Durable
 // GetLatestState fetches the latest durable state
 func (s DynamoDurableStore) GetLatestState(ctx context.Context, persistenceID string) (*egopb.DurableState, error) {
 	result, err := s.ddb.GetItem(ctx, persistenceID)
-	if err != nil {
+	switch {
+	case result == nil && err == nil:
+		return nil, nil
+	case err != nil:
 		return nil, err
+	default:
+		return result.ToDurableState()
 	}
-
-	return result.ToDurableState()
+}
 }

--- a/durablestore/dynamodb/dynamodb.go
+++ b/durablestore/dynamodb/dynamodb.go
@@ -40,13 +40,13 @@ func (ddb ddb) GetItem(ctx context.Context, persistenceID string) (*item, error)
 		TableName: aws.String(ddb.tableName),
 		Key:       key,
 	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch the latest state from the dynamodb: %w", err)
-	}
 
 	// Check if item exists
-	if result.Item == nil {
+	if result == nil {
 		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch the latest state from the dynamodb: %w", err)
 	}
 
 	return &item{

--- a/durablestore/dynamodb/dynamodb.go
+++ b/durablestore/dynamodb/dynamodb.go
@@ -44,6 +44,8 @@ func (ddb ddb) GetItem(ctx context.Context, persistenceID string) (*item, error)
 	switch {
 	case err != nil:
 		return nil, fmt.Errorf("failed to fetch the state from the dynamodb: %w", err)
+	case result == nil:
+		return nil, fmt.Errorf("failed to fetch the state from the dynamodb")
 	case result.Item == nil:
 		return nil, nil
 	default:

--- a/durablestore/dynamodb/dynamodb.go
+++ b/durablestore/dynamodb/dynamodb.go
@@ -42,7 +42,7 @@ func (ddb ddb) GetItem(ctx context.Context, persistenceID string) (*item, error)
 	})
 
 	// Check if item exists
-	if result == nil {
+	if result.Item == nil {
 		return nil, nil
 	}
 	if err != nil {

--- a/durablestore/dynamodb/dynamodb.go
+++ b/durablestore/dynamodb/dynamodb.go
@@ -43,7 +43,7 @@ func (ddb ddb) GetItem(ctx context.Context, persistenceID string) (*item, error)
 
 	switch {
 	case err != nil:
-		return nil, fmt.Errorf("failed to fetch the latest state from the dynamodb: %w", err)
+		return nil, fmt.Errorf("failed to fetch the state from the dynamodb: %w", err)
 	case result.Item == nil:
 		return nil, nil
 	default:


### PR DESCRIPTION
# Summary

Now, when creating a new durable actor, the `GetLatestState()` function will returns error because DynamoDB will complains that the item never exists in the table.

The correct behavior is that, when the item is not found, it should return nil error so that when the durable actor is spawned, it can set its state to initial state when it tries to run [`recoverFromStore`](https://github.com/Tochemey/ego/blob/main/durable_state_actor.go#L123)